### PR TITLE
Update globals.css

### DIFF
--- a/src/app/components/ExperienceListItem.tsx
+++ b/src/app/components/ExperienceListItem.tsx
@@ -43,7 +43,11 @@ export function ExperienceListItem({ data }: ExperienceListItemProps) {
             {job.titles?.length > 1 ? (
               <div>
                 {job.titles.slice(1).map((i) => (
-                  <div key={i} className="text-slate-500" aria-hidden="true">
+                  <div
+                    key={i}
+                    className="text-slate-500 text-sm"
+                    aria-hidden="true"
+                  >
                     {i}
                   </div>
                 ))}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,9 +41,9 @@ ul {
     padding-left: theme("padding.2");
     li {
       list-style-position: outside;
+      list-style-type: "▹";
       &::marker {
         color: theme("colors.teal.300");
-        content: "▹";
       }
     }
   }


### PR DESCRIPTION
Seems like the marker pseudo-element only supported `color` and `font-size` on Safari.